### PR TITLE
Update old links to new url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,11 @@
 # Contributing
+
 You can find our repo at [https://github.com/theta-tools/theta-tools](https://github.com/theta-tools/theta-tools)
 
-[Issues are always welcome](https://github.com/theta-tools/theta-tools.github.io/issues/new/choose), but if you're planning to modify code, and contribute new code, please follow the steps below.  
-  
-Firstly, read the [Contributing Guide](https://theta-tools.github.io/contributing)  
-Then, follow our [Contribution Plan](https://theta-tools.github.io/contributing/plan) to get setup with files and guidelines
+[Issues are always welcome](https://github.com/theta-tools/theta-tools.github.io/issues/new/choose), but if you're planning to modify code, and contribute new code, please follow the steps below.
+
+Firstly, read the [Contributing Guide](https://thetatools.xyz/contributing/)  
+Then, follow our [Contribution Plan](https://thetatools.xyz/contributing/plan/) to get setup with files and guidelines
 
 If you're a contributor and in our [Discord](https://discord.gg/P8RyW8F), you can let us know and we'll give you a special role
 
@@ -12,14 +13,14 @@ If you're a contributor and in our [Discord](https://discord.gg/P8RyW8F), you ca
 
 If you want to contribute to Theta Tools , that's great! We're always looking for more contributions. But, we ask that you follow certain guidelines when contributing.
 
-* Please correctly format your issues and pull requests
-* Please follow the guidelines in the [Contribution Plan](https://theta-tools.github.io/contributing/plan)
-* [V0.5+] Never commit directly to the `Main` branch. Open a new branch for commits
-  * Please name your branch according to the following specification `YOURUSERNAME/BRANCH-AIM`. E.G: `IzMichael/Add-ContactForm-Component`
+- Please correctly format your issues and pull requests
+- Please follow the guidelines in the [Contribution Plan](https://thetatools.xyz/contributing/plan/)
+- [V0.5+] Never commit directly to the `Main` branch. Open a new branch for commits
+  - Please name your branch according to the following specification `YOURUSERNAME/BRANCH-AIM`. E.G: `IzMichael/Add-ContactForm-Component`
 
 ## Code Formatting
 
 We only have a few guidelines for formatting code,
 
-* Please use 4 spaces for indentation
-* Use comments where necessary to explain the functions of certain sections
+- Please use 4 spaces for indentation
+- Use comments where necessary to explain the functions of certain sections

--- a/README.md
+++ b/README.md
@@ -1,22 +1,27 @@
 # Theta Tools
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Theta Tools are a set of HTML Based, Tailwind CSS Designed, pre-built components and assets that can be used in any project.  
-The project is currently based at [https://theta-tools.github.io/](https://theta-tools.github.io/)
+The project is currently based at [https://thetatools.xyz/](https://thetatools.xyz/)
 
 [Discord](https://discord.gg/P8RyW8F)
 
-You can find information on installation and usage at [https://theta-tools.github.io/docs](https://theta-tools.github.io/docs)
+You can find information on installation and usage at [https://theta-tools.github.io/docs](https://thetatools.xyz/docs/)
 
 ## Contributing
-[Issues are always welcome](https://github.com/theta-tools/theta-tools.github.io/issues/new/choose), but if you're planning to modify code, and contribute new code, please follow the steps below.  
-  
-Firstly, read the [Contributing Guide](https://theta-tools.github.io/contributing)  
-Then, follow our [Contribution Plan](https://theta-tools.github.io/contributing/plan) to get setup with files and guidelines
+
+[Issues are always welcome](https://github.com/theta-tools/theta-tools.github.io/issues/new/choose), but if you're planning to modify code, and contribute new code, please follow the steps below.
+
+Firstly, read the [Contributing Guide](https://thetatools.xyz/contributing/)  
+Then, follow our [Contribution Plan](https://thetatools.xyz/contributing/plan/) to get setup with files and guidelines
 
 ## License
+
 [MIT](https://choosealicense.com/licenses/mit)
 
 ## Contributors ✨
@@ -34,6 +39,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!


### PR DESCRIPTION
**Linked Issue(s)**
- Resolves #19 

**Describe the changes**
Updated the links that were "theta-tools.github.io" to "thetatools.xyz". I made sure to keep the ones pointing to specific pages pointing to those specific pages.

**Change(s) location**
- README.md
- CONTRIBUTING.md

**Additional context**
Let me know if I missed any or have any issues!
